### PR TITLE
Preparing for 0.1.5 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.1.5
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/philgooch/abbreviation-extraction.svg)](https://travis-ci.org/philgooch/abbreviation-extraction)
 
-## Version: 0.1.4
+## Version: 0.1.5
 
 This is a Python3 implementation of the [Schwartz-Hearst algorithm](https://psb.stanford.edu/psb-online/proceedings/psb03/schwartz.pdf)
 for identifying abbreviations and their corresponding definitions in free text[1].

--- a/abbreviations/schwartz_hearst.py
+++ b/abbreviations/schwartz_hearst.py
@@ -67,7 +67,7 @@ def best_candidates(sentence):
 
             if openindex == -1: break
 
-            # Look for closing parantheses
+            # Look for closing parentheses
             closeindex = openindex + 1
             open = 1
             skip = False
@@ -279,7 +279,6 @@ def extract_abbreviation_definition_pairs(file_path=None, doc_text=None):
             for candidate in best_candidates(sentence):
                 try:
                     definition = get_definition(candidate, sentence)
-                    log.info(definition)
                 except (ValueError, IndexError) as e:
                     log.debug("{} Omitting candidate {}. Reason: {}".format(i, candidate, e.args[0]))
                     omit += 1

--- a/abbreviations/schwartz_hearst.py
+++ b/abbreviations/schwartz_hearst.py
@@ -81,7 +81,7 @@ def best_candidates(sentence):
                     break
                 if char == '(':
                     open += 1
-                elif char == ')':
+                elif char in [')', ';', ':']:
                     open -= 1
                 closeindex += 1
 
@@ -148,8 +148,7 @@ def get_definition(candidate, sentence):
     :return: candidate definition for this abbreviation
     """
     # Take the tokens in front of the candidate
-    tokens = sentence[:candidate.start - 2].lower().split()
-
+    tokens = regex.split(r'[\s\-]', sentence[:candidate.start - 2].lower())
     # the char that we are looking for
     key = candidate[0].lower()
 
@@ -280,6 +279,7 @@ def extract_abbreviation_definition_pairs(file_path=None, doc_text=None):
             for candidate in best_candidates(sentence):
                 try:
                     definition = get_definition(candidate, sentence)
+                    log.info(definition)
                 except (ValueError, IndexError) as e:
                     log.debug("{} Omitting candidate {}. Reason: {}".format(i, candidate, e.args[0]))
                     omit += 1

--- a/test/features/schwartz_hearst.feature
+++ b/test/features/schwartz_hearst.feature
@@ -24,3 +24,16 @@ Feature: Extraction of abbreviations using Schwartz-Hearst algorithm
     Then "RNase P" should be mapped to "Ribonuclease P"
     Then "SDS-PAGE" should be mapped to "sodium dodecyl sulfate-polyacrylamide gel electrophoresis"
     Then "MALDI" should be mapped to "matrix-assisted laser desorption/ionization"
+
+
+    Given Text that I want to extract abbreviations from:
+    """
+    Theory of mind (ToM; Smith 2009) broadly refers to humans’ ability to represent the mental states of others,
+    including their desires, beliefs, and intentions.
+    Applications of text-to-speech (TTS) include:
+    We review astronomy and physics engagement with the
+    Open Researcher and Contributor iD (ORCID) service as a solution.
+    """
+    Then "ToM" should be mapped to "Theory of mind"
+    Then "TTS" should be mapped to "text-to-speech"
+    Then "ORCID" should be mapped to "Open Researcher and Contributor iD"


### PR DESCRIPTION
* Allows abbreviation to be delimited by ';' or ':' within parentheses 
* Tokenises definition candidates on both whitespace and hyphens