### PR TITLE
Fixes #25: 

### DIFF
--- a/abbreviations/schwartz_hearst.py
+++ b/abbreviations/schwartz_hearst.py
@@ -19,6 +19,8 @@ Biocomputing, 2003, pp 451-462.
 logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)
 log = logging.getLogger(__name__)
 
+PREPOSITIONS = regex.compile(r'\b(and|a[st]|[io]n|of|for|the)\b')
+
 
 class Candidate(str):
     def __init__(self, value):
@@ -118,17 +120,17 @@ def conditions(candidate):
     re.search(r'\p{L}', str)
     str[0].isalnum()
 
-    and extra:
-    if it matches (\p{L}\.?\s?){2,}
-    it is a good candidate.
+    Plus:
+    cannot be all lowercase and longer than 7 chars
+    (see https://github.com/philgooch/abbreviation-extraction/issues/25)
 
     :param candidate: candidate abbreviation
     :return: True if this is a good candidate
     """
     viable = True
-    if regex.match(r'(\p{L}\.?\s?){2,}', candidate.lstrip()):
-        viable = True
     if len(candidate) < 2 or len(candidate) > 10:
+        viable = False
+    if regex.match(r'^\p{Ll}{7,}$', candidate):
         viable = False
     if len(candidate.split()) > 2:
         viable = False
@@ -176,6 +178,14 @@ def get_definition(candidate, sentence):
             # Look up key in the definition
             try:
                 start_index = first_chars.index(key, len(first_chars) + start)
+                # Check that the candidate definition does not start with a preposition or conjunction
+                sniffer_start = len(' '.join(tokens[:start_index]))
+                preposition = sentence[sniffer_start:sniffer_start+4].strip()
+                if PREPOSITIONS.match(preposition):
+                    # If it does, rewind
+                    count -= 1
+                    start -= 1
+                    start_index -= 1
             except ValueError:
                 pass
 
@@ -252,7 +262,10 @@ def select_definition(definition, abbrev):
 
     new_candidate = Candidate(definition[l_index:len(definition)])
     new_candidate.set_position(definition.start, definition.stop)
-    definition = new_candidate
+
+    # Check that the new candidate does not start with a preposition or conjunction
+    if not PREPOSITIONS.match(new_candidate):
+        definition = new_candidate
 
     tokens = len(definition.split())
     length = len(abbrev)

--- a/test/features/schwartz_hearst.feature
+++ b/test/features/schwartz_hearst.feature
@@ -41,6 +41,17 @@ Feature: Extraction of abbreviations using Schwartz-Hearst algorithm
     Then "PoCA 2002" should be mapped to "Proceeds of Crime Act 2002"
 
 
+    Given Text that I want to extract abbreviations from:
+    """
+    The “satellite” goal of the program was accomplished when China established a space presence with the launch of Dongfanghong I in 1970; although, it wasn’t until the 21st century that the PRC space program kicked into high gear, with the rapid development, buildup and deployment of rockets, satellites, and the first Taikonaut (astronaut) in October 2003. In fact, prior to 2010, the PRC had only conducted ten space launches, one of which put the satellite into orbit.
+    Once more, also for the Space Race, a strong transatlantic link could strengthen the path towards a peaceful and prosperous future for humankind and by consequence, a more secure period for our democracies: it is in our hands (and brains) to transform these ideas into a great reality.
+    Berlin is acknowledging the vulnerabilities that could potentially arise through hostile acts in space and set up its own space monitoring center, called the Air and Space Operations Center (ASOC) in September 2020 .
+    """
+    Then "ASOC" should be mapped to "Air and Space Operations Center"
+    Then "astronaut" should be null
+    Then "and brains" should be null
+
+
     Given Text that does not contain a valid abbreviation:
     """
     Bayesian linear regression of actual log(RT)


### PR DESCRIPTION
- See https://github.com/philgooch/abbreviation-extraction/issues/25
- Reduces false positives by introducing short-form candidate casing and length constraint, and rewinding if candidate definition starts with an English preposition