### PR TITLE
Only enable logging if run as a script

### DIFF
--- a/abbreviations/schwartz_hearst.py
+++ b/abbreviations/schwartz_hearst.py
@@ -16,7 +16,6 @@ Biocomputing, 2003, pp 451-462.
 
 """
 
-logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)
 log = logging.getLogger(__name__)
 
 
@@ -332,4 +331,5 @@ def extract_abbreviation_definition_pairs(file_path=None,
 
 
 if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)
     print(extract_abbreviation_definition_pairs(file_path=sys.argv[1]))


### PR DESCRIPTION
* if the caller uses schwartz_hearst as a library, they probably want to have full control
    over enabling logging, as opposed to the existing call to `basicConfig`
* if the caller uses schwartz_hearst as a script, then the call to `basicConfig` is
    perfectly appropriate, but can live in the `__main__` block
